### PR TITLE
Add ACL-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following configuration options are available:
 * **SourcesKeysPath**: The path to where the private keys of the sources are found. The keys must be in PEM-format and must have the file-extension \*.priv
 * **TicketKeysPath**: The public keys for tickets that should be acceptable
 * **SampleStorageURI**: The URI where the samples reside. This URI is prepended to the PrimaryURI- and SecondaryURI-fields for incoming tasks
+* **AllowedTasks**: A dict indicating, which organization is allowed to request which task. To allow all tasks of an organization use the wildcard '\*'.
 * **RabbitURI**: The URI to rabbit
 * **RabbitUser**: The rabbit username
 * **RabbitPassword**: The rabbit password
@@ -112,12 +113,12 @@ The following demonstrates an exemplary evocation using CURL.
 The *--insecure* parameter is used, to disable certificate checking.
 
 ```sh
-curl --data 'username=test&password=test&task=[{"primaryURI":"3a12f43eeb0c45d241a8f447d4661d9746d6ea35990953334f5ec675f60e36c5","secondaryURI":"","filename":"myfile","tasks":{"PEINFO":[""],"YARA":[""]},"tags":["test1"],"attempts":0,"source":"foo","download":true}]' --insecure https://localhost:8090/task/
+curl --data 'username=test&password=test&task=[{"primaryURI":"3a12f43eeb0c45d241a8f447d4661d9746d6ea35990953334f5ec675f60e36c5","secondaryURI":"","filename":"myfile","tasks":{"PEINFO":[],"YARA":[]},"tags":["test1"],"attempts":0,"source":"src1","download":true}]' --insecure https://localhost:8090/task/
 ```
 
 Alternatively, it is possible to use Holmes-Toolbox for this task, as well. First a file must be prepared containing a line with the sha256-sum, the filename, and the source (separated by single spaces) for each sample.
 ```sh
-./Holmes-Toolbox --gateway https://127.0.0.1:8090 --tasking --file sampleFile --user test --pw test --tasks '{"PEINFO":[""], "YARA":[""]}' --tags '["mytag"]' --comment 'mycomment' --insecure
+./Holmes-Toolbox --gateway https://127.0.0.1:8090 --tasking --file sampleFile --user test --pw test --tasks '{"PEINFO":[], "YARA":[]}' --tags '["mytag"]' --comment 'mycomment' --insecure
 ```
 
 If no error occured, nothing or an empty list will be returned. Otherwise a list containing the

--- a/config.json.example
+++ b/config.json.example
@@ -3,6 +3,7 @@
 	"SourcesKeysPath":    "keys",
 	"TicketKeysPath":     "keys",
 	"SampleStorageURI":   "http://localhost:8016/samples/",
+	"AllowedTasks":       {"sign": ["*"], "org2": ["PEINFO"]},
 	"RabbitURI":          "localhost:5672/",
 	"RabbitUser":         "guest",
 	"RabbitPassword":     "guest",

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -172,7 +172,8 @@ func handleDecrypted(ticketStr string) (*tasking.MyError, []tasking.TaskError) {
 			}
 			log.Printf("Allowed: %+v\n", acceptedTasks)
 			log.Printf("Rejected: %+v\n", rejectedTasks)
-
+			savedPrimaryURI := task.PrimaryURI
+			savedSecondaryURI := task.SecondaryURI
 			task.PrimaryURI = conf.SampleStorageURI + task.PrimaryURI
 			if task.SecondaryURI != "" {
 				task.SecondaryURI = conf.SampleStorageURI + task.SecondaryURI
@@ -180,6 +181,8 @@ func handleDecrypted(ticketStr string) (*tasking.MyError, []tasking.TaskError) {
 			task.Tasks = acceptedTasks
 			pushToTransport(task)
 			if len(rejectedTasks) != 0 {
+				task.PrimaryURI = savedPrimaryURI
+				task.SecondaryURI = savedSecondaryURI
 				task.Tasks = rejectedTasks
 				e2 := tasking.MyError{Error: errors.New("Rejected"), Code: tasking.ERR_NOT_ALLOWED}
 				tskerrors = append(tskerrors, tasking.TaskError{

--- a/mastergateway/mastergateway.go
+++ b/mastergateway/mastergateway.go
@@ -40,7 +40,7 @@ var (
 	keysMutex = &sync.Mutex{}                  // Mutex for the map, since keys could change during runtime
 	ticketSignKey *rsa.PrivateKey              // The private key used for signing tickets
 	ticketSignKeyName string                   // The id of the private key used for signing tickets
-	srcRouter map[string]*tasking.Organization // Which source should be routed to which organization
+	srcRouter map[string][]*tasking.Organization // Which source should be routed to which organization
 	ownOrganization *tasking.Organization      // Pointer to the own organization in the list of organizations
 	storageURI url.URL                         // The URL to storage for redirecting object-storage requests
 	proxy *httputil.ReverseProxy               // The proxy object for redirecting object-storage requests
@@ -67,7 +67,6 @@ func encryptKey(symKey []byte, asymKeyId string) ([]byte, error) {
 	asymKey, exists := keys[asymKeyId]
 	keysMutex.Unlock()
 	log.Println("searching for key: " + asymKeyId)
-	log.Printf("%+v\n", keys)
 	if !exists {
 		return nil, errors.New("Public Key not found")
 	}
@@ -150,66 +149,94 @@ func handleTask(tasksStr string, username string, password string) (error, []tas
 		return err, tskerrors
 	}
 
-	// Sort the tasks for their destination organizations, based on the
-	// source of the task and the srcRouter-configuration
-	tasklists := make(map[*tasking.Organization][]tasking.Task)
-	for _,task := range tasks {
-		org, found := srcRouter[task.Source]
-		if !found {
-			log.Printf("No route for source %s!\n", task.Source)
-			tskerrors = append(tskerrors, tasking.TaskError{
-				TaskStruct : task,
-				Error : tasking.MyError{Error: errors.New("No route for source!")}})
-			continue
+	// Submit all the tasks, until either all of them are either accepted
+	// or unrecoverable rejected
+	unrecoverableErrors := make([]tasking.TaskError, 0, len(tasks))
+	iteration := 0
+	for len(tasks) > 0 {
+		tskerrors = tskerrors[0:0]
+		log.Printf("\x1b[0;32mSending tasks try #%d\x1b[0m\n", iteration)
+		
+		// Sort the tasks for their destination organizations, based on the
+		// source of the task and the srcRouter-configuration
+		tasklists := make(map[*tasking.Organization][]tasking.Task)
+		for _,task := range tasks {
+			orgs, found := srcRouter[task.Source]
+			if !found {
+				log.Printf("No route for source %s!\n", task.Source)
+				unrecoverableErrors = append(unrecoverableErrors, tasking.TaskError{
+					TaskStruct : task,
+					Error : tasking.MyError{Error: errors.New("No route for source!")}})
+				continue
+			}
+			if len(orgs) <= iteration {
+				unrecoverableErrors = append(unrecoverableErrors, tasking.TaskError{
+					TaskStruct : task,
+					Error : tasking.MyError{Error: errors.New("Task rejected by all organizations!")}})
+				continue
+			}
+			org := orgs[iteration]
+			tasklist, found := tasklists[org]
+			// TODO: Is this efficient?
+			if !found {
+				tasklists[org] = []tasking.Task{task}
+			} else {
+				tasklists[org] = append(tasklist, task)
+			}
 		}
-		tasklist, found := tasklists[org]
-		// TODO: Is this efficient?
-		if !found {
-			tasklists[org] = []tasking.Task{task}
-		} else {
-			tasklists[org] = append(tasklist, task)
+		// Send the tasks and handle the answers
+		for org, tasklist := range tasklists {
+			err, answerString := sendTaskList(tasklist, org)
+			if err != nil {
+				log.Println("Error while sending tasks: ", err)
+				for task := range tasklist {
+					tskerrors = append(tskerrors, tasking.TaskError{
+						TaskStruct : tasklist[task],
+						Error: tasking.MyError{Error: errors.New("Error while sending task! " + err.Error())}})
+				}
+				continue
+			}
+			var answer tasking.GatewayAnswer
+			err = json.Unmarshal(answerString, &answer)
+			if err != nil {
+				log.Printf("Error while parsing result")
+				for task := range tasklist {
+					tskerrors = append(tskerrors, tasking.TaskError{
+						TaskStruct : tasklist[task],
+						Error: tasking.MyError{Error: errors.New("Error while parsing result! " + err.Error())}})
+				}
+				continue
+
+			} else if answer.Error != nil {
+				log.Printf("Error: ", answer.Error)
+				for task := range tasklist {
+					tskerrors = append(tskerrors, tasking.TaskError{
+						TaskStruct : tasklist[task],
+						Error: *answer.Error,
+					})
+				}
+				continue
+			}
+			tskerrors = append(tskerrors, answer.TskErrors...)
+		}
+		// go through list of tskerrors and reissue those with a recoverable error-code
+		log.Printf("\x1b[0;33mreceived errors: %+v\x1b[0m", tskerrors)
+		iteration += 1
+		tasks = make([]tasking.Task, 0, len(tskerrors))
+		for _, e := range tskerrors {
+			switch e.Error.Code {
+			case tasking.ERR_OTHER_UNRECOVERABLE, tasking.ERR_TASK_INVALID:
+				// These tasks are not recoverable and won't be reissued
+				unrecoverableErrors = append(unrecoverableErrors, e)
+				break
+			default:
+				tasks = append(tasks, e.TaskStruct)
+			}
 		}
 	}
+	log.Printf("\x1b[0;31mUnrecoverable Errors: %+v\x1b[0m", unrecoverableErrors)
 
-	for org, tasklist := range tasklists {
-		err, answer := sendTaskList(tasklist, org)
-		if err != nil {
-			log.Println("Error while sending tasks: ", err)
-			for task := range tasklist {
-				tskerrors = append(tskerrors, tasking.TaskError{
-					TaskStruct : tasklist[task],
-					Error: tasking.MyError{Error: errors.New("Error while sending task! " + err.Error())}})
-			}
-			continue
-		}
-		var answerP tasking.GatewayAnswer
-		err = json.Unmarshal(answer, &answerP)
-		if err != nil {
-			log.Printf("Error while parsing result")
-			for task := range tasklist {
-				tskerrors = append(tskerrors, tasking.TaskError{
-					TaskStruct : tasklist[task],
-					Error: tasking.MyError{Error: errors.New("Error while parsing result! " + err.Error())}})
-			}
-			continue
-
-		} else if answerP.Error != nil {
-			log.Printf("Error: ", answerP.Error)
-			for task := range tasklist {
-				tskerrors = append(tskerrors, tasking.TaskError{
-					TaskStruct : tasklist[task],
-					Error: *answerP.Error,
-				})
-			}
-			continue
-		}
-		tskerrors = append(tskerrors, answerP.TskErrors...)
-	}
-
-	// TODO:
-	// go through list of tskerrors and reissue those with a recoverable error-code
-
-	return nil, tskerrors
+	return nil, unrecoverableErrors
 }
 
 func sendTaskList(tasks []tasking.Task, org *tasking.Organization) (error, []byte){
@@ -428,12 +455,18 @@ func initHTTP() {
 func initSourceRouting() {
 	//TODO: make this dynamically configurable
 	ownOrganization = nil
-	srcRouter = make(map[string]*tasking.Organization)
+	srcRouter = make(map[string][]*tasking.Organization)
+
 	log.Println("=====")
 	for num, org := range(conf.Organizations) {
 		log.Println(org)
 		for _, src := range(org.Sources) {
-			srcRouter[src] = &conf.Organizations[num]
+			routes, exists := srcRouter[src]
+			if !exists {
+				srcRouter[src] = []*tasking.Organization{&conf.Organizations[num]}
+			} else {
+				srcRouter[src] = append(routes, &conf.Organizations[num])
+			}
 		}
 		if org.Name == conf.OwnOrganization {
 			ownOrganization = &conf.Organizations[num]

--- a/submit_task.html
+++ b/submit_task.html
@@ -32,7 +32,7 @@
 			
 		}
 		function append_example(){
-			$(taskarea).val($(taskarea).val()+'{"primaryURI":"3a12f43eeb0c45d241a8f447d4661d9746d6ea35990953334f5ec675f60e36c5","secondaryURI":"","filename":"myfile","tasks":{"PEINFO":[""],"YARA":[""]},"tags":["test1"],"attempts":0,"source":"foo","download":true}\n');
+			$(taskarea).val($(taskarea).val()+'{"primaryURI":"3a12f43eeb0c45d241a8f447d4661d9746d6ea35990953334f5ec675f60e36c5","secondaryURI":"","filename":"myfile","tasks":{"PEINFO":[],"YARA":[]},"tags":["test1"],"attempts":0,"source":"foo","download":true}\n');
 		}
 	</script>
 	<body>

--- a/utils/tasking.go
+++ b/utils/tasking.go
@@ -62,10 +62,12 @@ type User struct {
 
 type ErrCode int
 const (
-	ERR_NONE ErrCode   = 1 + iota
-	ERR_KEY_UNKNOWN    = iota
-	ERR_ENCRYPTION     = iota
-	ERR_OTHER          = iota
+	ERR_NONE ErrCode        = 1 + iota
+	ERR_KEY_UNKNOWN         = iota
+	ERR_ENCRYPTION          = iota
+	ERR_TASK_INVALID        = iota
+	ERR_OTHER_UNRECOVERABLE = iota
+	ERR_OTHER_RECOVERABLE   = iota
 )
 
 type MyError struct {
@@ -76,6 +78,11 @@ type MyError struct {
 type TaskError struct {
 	TaskStruct  Task
 	Error       MyError
+}
+
+type GatewayAnswer struct {
+	Error *MyError
+	TskErrors []TaskError
 }
 
 func (me MyError) MarshalJSON() ([]byte, error) {

--- a/utils/tasking.go
+++ b/utils/tasking.go
@@ -60,23 +60,43 @@ type User struct {
 	PasswordHash string `json:"pw"`
 }
 
+type ErrCode int
+const (
+	ERR_NONE ErrCode   = 1 + iota
+	ERR_KEY_UNKNOWN    = iota
+	ERR_ENCRYPTION     = iota
+	ERR_OTHER          = iota
+)
+
 type MyError struct {
 	Error error
+	Code  ErrCode
 }
 
 type TaskError struct {
-	TaskStruct Task
+	TaskStruct  Task
 	Error       MyError
 }
 
 func (me MyError) MarshalJSON() ([]byte, error) {
-	return json.Marshal(me.Error.Error())
+	return json.Marshal(
+		struct{
+			Error string
+			Code ErrCode
+		}{
+			Error: me.Error.Error(),
+			Code: me.Code,
+		})
 }
 
 func (me *MyError) UnmarshalJSON(data []byte) error {
-	var s string
+	var s struct{
+		Error string
+		Code ErrCode
+	}
 	err := json.Unmarshal(data, &s)
-	me.Error = errors.New(s)
+	me.Error = errors.New(s.Error)
+	me.Code = s.Code
 	return err
 }
 

--- a/utils/tasking.go
+++ b/utils/tasking.go
@@ -66,6 +66,7 @@ const (
 	ERR_KEY_UNKNOWN         = iota
 	ERR_ENCRYPTION          = iota
 	ERR_TASK_INVALID        = iota
+	ERR_NOT_ALLOWED         = iota
 	ERR_OTHER_UNRECOVERABLE = iota
 	ERR_OTHER_RECOVERABLE   = iota
 )


### PR DESCRIPTION
Slave-Gateways must be configured, which tasks to accept and which to reject. Master-Gateway will automatically re-issue tasks that are rejected to different Slave-Gateways if more than one provider for a source is known.

This Pull Request goes quite deep into the core of Holmes-Gateway, as it adds Error-Codes to determine, whether an error is considered "recoverable", and thus re-issued to a different Slave or "non-recoverable" and returned to the user. A "recoverable" error is e.g. a rejection based on ACL, an example for a non-recoverable error is a corrupt task-struct.
