### PR TITLE
tasks are now grouped according to source instead of destination gateway

### DIFF
--- a/config/keys/generate_key.go
+++ b/config/keys/generate_key.go
@@ -4,9 +4,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-	"os"
 	"encoding/pem"
 	"log"
+	"os"
 )
 
 func main() {
@@ -15,14 +15,14 @@ func main() {
 	}
 	fname := os.Args[1]
 	log.Println(fname)
-	priv, err := rsa.GenerateKey(rand.Reader,1024)
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		log.Fatal("Error generating key:", err)
 	}
 
 	pemdataPriv := pem.EncodeToMemory(
 		&pem.Block{
-			Type: "RSA PRIVATE KEY",
+			Type:  "RSA PRIVATE KEY",
 			Bytes: x509.MarshalPKCS1PrivateKey(priv),
 		},
 	)
@@ -33,13 +33,13 @@ func main() {
 
 	pemdataPub := pem.EncodeToMemory(
 		&pem.Block{
-			Type: "RSA PUBLIC KEY",
+			Type:  "RSA PUBLIC KEY",
 			Bytes: pub,
 		},
 	)
-	fPriv, err := os.Create("./"+fname+".priv")
+	fPriv, err := os.Create("./" + fname + ".priv")
 
-	fPub, err := os.Create("./"+fname+".pub")
+	fPub, err := os.Create("./" + fname + ".pub")
 	_, err = fPriv.Write(pemdataPriv)
 	_, err = fPub.Write(pemdataPub)
 	log.Printf("%+v\n", priv)

--- a/submit_task.html
+++ b/submit_task.html
@@ -32,7 +32,7 @@
 			
 		}
 		function append_example(){
-			$(taskarea).val($(taskarea).val()+'{"primaryURI":"3a12f43eeb0c45d241a8f447d4661d9746d6ea35990953334f5ec675f60e36c5","secondaryURI":"","filename":"myfile","tasks":{"PEINFO":[],"YARA":[]},"tags":["test1"],"attempts":0,"source":"foo","download":true}\n');
+			$(taskarea).val($(taskarea).val()+'{"primaryURI":"3a12f43eeb0c45d241a8f447d4661d9746d6ea35990953334f5ec675f60e36c5","secondaryURI":"","filename":"myfile","tasks":{"PEINFO":[],"YARA":[]},"tags":["test1"],"attempts":0,"source":"src1","download":true}\n');
 		}
 	</script>
 	<body>


### PR DESCRIPTION
Previously all the tasks which would end up on the same slave-gateway were batched together and encrypted with the key of the source of the first of these tasks.
Now the tasks are grouped based on their source and each list of tasks is encrypted and sent individually with the key of that source.
