### PR TITLE
Maximum Upload Size configureable; meaningfull error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following configuration options are available:
 * **AutoTasks**: A dict mapping the mimetype to a dict of tasks, that should be executed automatically whenever a sample is uploaded. The mimetype returned by storage is checked against every value in the dict. If the value from the dict is contained in the returned value, all the corresponding tasks are executed. e.g.: `{"PE32":{"PEINFO":[],"PEID":[]}, "":{"YARA":[]}}` means that for every uploaded file the service "YARA" is executed (since every string contains ""). Additionally, files with a memetype, which contains "PE32", the services "PEINFO" and "PEID" are executed.
 * **CertificateKeyPath**: The path to the key of the HTTPS-certificate
 * **CertificatePath**: The path to the HTTPS-certificate
+* **MaxUploadSize**: The maximum allowed size in MB for uploading samples. Defaults to 200 MB, if no value is configured
 
 Start up the Master-Gateway by calling
 

--- a/config/gateway-master.conf.example
+++ b/config/gateway-master.conf.example
@@ -11,4 +11,5 @@
 	"AutoTasks":         {"PE32":{"PEINFO":[],"PEID":[]}, "":{"YARA":[]}},
 	"CertificateKeyPath":"cert-key.pem",
 	"CertificatePath":   "cert.pem"
+	"MaxUploadSize":     200
 }

--- a/mastergateway/mastergateway.go
+++ b/mastergateway/mastergateway.go
@@ -31,7 +31,7 @@ type config struct {
 	OwnOrganization    string                           // The name of the own organization (Should also be present in the list "Organizations")
 	StorageURI         string                           // URI of HolmesStorage
 	AutoTasks          map[string](map[string][]string) // Tasks that should be automatically executed on new objects mimetype -> taskname -> args
-	MaxUploadSize      int64                            // The maximum size of a sample-upload in Megabyte
+	MaxUploadSize      uint32                           // The maximum size of a sample-upload in Megabyte
 	CertificatePath    string
 	CertificateKeyPath string
 	AllowedUsers       []tasking.User
@@ -373,7 +373,7 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	// For this reason, the whole body is read and a new reader is created,
 	// which can be rewinded.
 	var err error
-	if request.ContentLength > 1024*1024*conf.MaxUploadSize {
+	if request.ContentLength > 1024*1024*int64(conf.MaxUploadSize) {
 		respBody := ioutil.NopCloser(bytes.NewBufferString("Upload too large"))
 		resp := &http.Response{StatusCode: 413, Body: respBody}
 		respBody.Close()
@@ -396,7 +396,7 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 		reqrdr.Close()
 	}()
 
-	request.ParseMultipartForm(1024 * 1024 * conf.MaxUploadSize)
+	request.ParseMultipartForm(1024 * 1024 * int64(conf.MaxUploadSize))
 	// Read the name and the source from the request, because they can not be
 	// reconstructed from storage's response.
 	name := request.FormValue("name")

--- a/mastergateway/mastergateway.go
+++ b/mastergateway/mastergateway.go
@@ -31,6 +31,7 @@ type config struct {
 	OwnOrganization    string                           // The name of the own organization (Should also be present in the list "Organizations")
 	StorageURI         string                           // URI of HolmesStorage
 	AutoTasks          map[string](map[string][]string) // Tasks that should be automatically executed on new objects mimetype -> taskname -> args
+	MaxUploadSize      int64                            // The maximum size of a sample-upload in Megabyte
 	CertificatePath    string
 	CertificateKeyPath string
 	AllowedUsers       []tasking.User
@@ -372,6 +373,13 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	// For this reason, the whole body is read and a new reader is created,
 	// which can be rewinded.
 	var err error
+	if request.ContentLength > 1024*1024*conf.MaxUploadSize {
+		respBody := ioutil.NopCloser(bytes.NewBufferString("Upload too large"))
+		resp := &http.Response{StatusCode: 413, Body: respBody}
+		respBody.Close()
+		log.Println("Upload too large")
+		return resp, nil
+	}
 	reqbuf := make([]byte, request.ContentLength)
 	_, err = io.ReadFull(request.Body, reqbuf)
 	if err != nil {
@@ -388,7 +396,7 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 		reqrdr.Close()
 	}()
 
-	request.ParseMultipartForm(1024 * 1024 * 200)
+	request.ParseMultipartForm(1024 * 1024 * conf.MaxUploadSize)
 	// Read the name and the source from the request, because they can not be
 	// reconstructed from storage's response.
 	name := request.FormValue("name")
@@ -551,7 +559,7 @@ func initUsers() {
 
 func Start(confPath string) {
 	// Parse the configuration
-	conf = &config{}
+	conf = &config{MaxUploadSize: 200}
 	cfile, _ := os.Open(confPath)
 	err := json.NewDecoder(cfile).Decode(&conf)
 	tasking.FailOnError(err, "Couldn't read config file")


### PR DESCRIPTION
There is a new configuration option for Master-Gateway, called "MaxUploadSize". If the sample size is bigger than the configured maximum, a 413-Error is returned, with an according error message.
This closes https://github.com/HolmesProcessing/Holmes-Gateway/issues/26
