### PR TITLE
Try to restore AMQP-connection

### DIFF
--- a/config/gateway.conf.example
+++ b/config/gateway.conf.example
@@ -3,7 +3,7 @@
 	"SourcesKeysPath":    "config/keys/sources/",
 	"TicketKeysPath":     "config/keys/tickets/",
 	"SampleStorageURI":   "http://localhost:8016/samples/",
-	"AllowedTasks":       {"org1": ["*"], "org2": ["peinfo"]},
+	"AllowedTasks":       {"org1": ["*"], "org2": ["PEINFO"]},
 	"RabbitURI":          "localhost:5672/",
 	"RabbitUser":         "guest",
 	"RabbitPassword":     "guest",

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"time"
 )
@@ -159,7 +158,6 @@ func handleDecrypted(ticketStr string) (*tasking.MyError, []tasking.TaskError) {
 				acceptedTasks = task.Tasks
 			} else {
 				for tsk, arg := range task.Tasks {
-					tsk = strings.ToLower(tsk)
 					_, tAllowed := allowedForOrg[tsk]
 					if tAllowed {
 						acceptedTasks[tsk] = arg
@@ -494,8 +492,7 @@ func Start(confPath string) {
 	ticketKeys = make(map[string]*rsa.PublicKey)
 	readKeys()
 
-	// Make sure, allowed tasks are in lower case, as they are compared
-	// case insensitive. Also bring them into a map, since this is more
+	// bring the keys into a map, since this is more
 	// efficient in our case
 	allowedTasks = make(map[string](map[string]struct{}))
 	for org, tasks := range conf.AllowedTasks {
@@ -503,7 +500,7 @@ func Start(confPath string) {
 		for _, t := range tasks {
 			// struct{}{} is just an empty placeholder.
 			// we are only interested in whether the key exists in the map
-			allowed[strings.ToLower(t)] = struct{}{}
+			allowed[t] = struct{}{}
 		}
 		allowedTasks[org] = allowed
 	}


### PR DESCRIPTION
If the AMQP-connection dies while gateway is running, gateway does not notice this and just discards the tasks without further error message.

This Pull Request fixes this behaviour: Gateway tries to restore a dead connection up to three times, before giving up and rejecting the task, so Master-Gateway can try and find some other Slave-Gateway to execute the task.
Notice, that if all known Slave-Gateways have dead AMQP-connections, the error Master-Gateway will tell you, is "Task rejected by all organizations".

Furthermore, this Pull Request also fixes an inconsistency, which could lead to all tasks in AMQP being spelled in lower-case and thus being rejected by Totem. This only occured, when a Slave-Gateway only allows certain tasks from an organization, instead of allowing all tasks (by using the wildcard ["*"] in the config).