### PR TITLE
Don't report Success, if upload resulted in anything other than 200

### DIFF
--- a/mastergateway/mastergateway.go
+++ b/mastergateway/mastergateway.go
@@ -462,6 +462,10 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
+	if response.StatusCode != 200 {
+		log.Printf("Error: Received %d\n", response.StatusCode)
+		return response, err
+	}
 	// Parse the response. If it was successful, execute automatic tasks
 	var resp storageResponse
 	log.Printf("%+v\n", response)


### PR DESCRIPTION
Don't report Success, if upload resulted in anything other than 200.
This also prevents automatic tasks to be executed, if an http-response-code other than 200 is received.