### PR TITLE
Minor fix

### DIFF
--- a/config/gateway-master.conf.example
+++ b/config/gateway-master.conf.example
@@ -10,6 +10,6 @@
 	"StorageURI":        "http://localhost:8016/samples/",
 	"AutoTasks":         {"PE32":{"PEINFO":[],"PEID":[]}, "":{"YARA":[]}},
 	"CertificateKeyPath":"cert-key.pem",
-	"CertificatePath":   "cert.pem"
+	"CertificatePath":   "cert.pem",
 	"MaxUploadSize":     200
 }


### PR DESCRIPTION
Without this, it will show an error  
`Couldn't read config file: invalid character '"' after object key:value pair`